### PR TITLE
Fix validate_enzyme_rates for Ping Pong rate equations (0/0 NaN)

### DIFF
--- a/src/validate.jl
+++ b/src/validate.jl
@@ -362,7 +362,19 @@ function validate_enzyme_rates(
         for metab in [substrate_names..., product_names...]
             empty_metabs[metab] = 0.0
         end
-        rate(Enzyme(Enz...), empty_metabs, rand_params) == 0.0 || error("Enzyme $(Enz[1]) rate should be zero when all substrates and products are absent.")
+        zero_rate = rate(Enzyme(Enz...), empty_metabs, rand_params)
+        if isnan(zero_rate)
+            # Ping Pong and similar mechanisms produce 0/0 = NaN at exactly zero
+            # concentrations. Fall back to checking the limit approaches zero.
+            near_zero_metabs = deepcopy(rand_test_metabs)
+            for metab in [substrate_names..., product_names...]
+                near_zero_metabs[metab] = eps(Float64)
+            end
+            near_zero_rate = rate(Enzyme(Enz...), near_zero_metabs, rand_params)
+            isapprox(near_zero_rate, 0.0; atol=1e-8) || error("Enzyme $(Enz[1]) rate should approach zero when all substrates and products approach zero, but got $(near_zero_rate).")
+        else
+            zero_rate == 0.0 || error("Enzyme $(Enz[1]) rate should be zero when all substrates and products are absent.")
+        end
 
         # rate is zero when substrates and products are at equilibrium
         equilibrium_metabs = deepcopy(rand_test_metabs)

--- a/test/tests_validate.jl
+++ b/test/tests_validate.jl
@@ -561,6 +561,49 @@
         product_activator_params,
     )
 
+    # ------- Test: Ping Pong Bi Bi passes validation (0/0 NaN fallback) -------
+    # Ping Pong mechanisms lack a free-enzyme constant term in the denominator,
+    # so both numerator and denominator are zero when all substrates/products are
+    # zero, producing NaN. The validator should handle this via the limit fallback.
+    pingpong_pathway =
+        MetabolicPathway((), ((:PingPongEnz, (:A, :B), (:P, :Q)),))
+
+    function CellMetabolismBase.rate(
+        ::Enzyme{:PingPongEnz,(:A, :B),(:P, :Q)},
+        metabs,
+        params,
+    )
+        Vmax = params.PingPongEnz_Vmax
+        Keq = params.PingPongEnz_Keq
+        K_A = params.PingPongEnz_K_A
+        K_B = params.PingPongEnz_K_B
+        K_P = params.PingPongEnz_K_P
+        K_Q = params.PingPongEnz_K_Q
+        A, B, P, Q = metabs.A, metabs.B, metabs.P, metabs.Q
+
+        num = Vmax * (A * B - P * Q / Keq)
+        denom = K_B * A + K_A * B + A * B +
+                K_Q * P / Keq + K_P * Q / Keq + P * Q / Keq +
+                K_B * A * Q / K_Q + K_A * B * P / K_P
+        return num / denom
+    end
+
+    pingpong_metabs = LVector(A = 1.0, B = 0.5, P = 0.2, Q = 0.1)
+    pingpong_params = LVector(
+        PingPongEnz_Vmax = 1.0,
+        PingPongEnz_Keq = 5.0,
+        PingPongEnz_K_A = 0.3,
+        PingPongEnz_K_B = 0.2,
+        PingPongEnz_K_P = 0.4,
+        PingPongEnz_K_Q = 0.5,
+    )
+
+    @test_nowarn CellMetabolismBase.validate_enzyme_rates(
+        pingpong_pathway,
+        pingpong_metabs,
+        pingpong_params,
+    )
+
     # ------- Test: Enzyme rate is zero when all substrates and products absent -------
     # Create a specialized test for this case
     never_zero_pathway = MetabolicPathway((:S_ext,), ((:NeverZeroEnz, (:S_ext,), (:S,)),))


### PR DESCRIPTION
## Summary
- `validate_enzyme_rates` evaluates rates at zero substrate/product concentrations
  and expects exactly `0.0`. Ping Pong mechanisms have no free-enzyme constant term
  in the denominator, so both numerator and denominator are zero, giving `NaN`.
- When the result is `NaN`, fall back to evaluating at `eps(Float64)` and check
  that the rate is approximately zero.
- Equations that return `0.0` directly still use the original strict check.
- Added regression test with a Ping Pong Bi Bi rate equation.

Closes #26

## Test plan
- [x] All 209 existing tests pass
- [x] New Ping Pong Bi Bi test (would fail before this fix, passes now)

🤖 Generated with [Claude Code](https://claude.com/claude-code)