### PR TITLE
New feature: `conserved_moieties` gets the groups of metabolites that are conserved in a metabolic pathway

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ authors = ["Denis Titov <titov@berkeley.edu>  and contributors"]
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 LabelledArrays = "2ee39098-c373-598a-b85f-a56591580800"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 
 [compat]
@@ -17,6 +18,7 @@ JET = "0.10, 0.11"
 LabelledArrays = "1.16.0"
 OrdinaryDiffEqFIRK = "2"
 SciMLBase = "3"
+LinearAlgebra = "1.12.0"
 Random = "1.11.0"
 SparseArrays = "1.12.0"
 StatsBase = "0.34.11"

--- a/Project.toml
+++ b/Project.toml
@@ -17,6 +17,9 @@ JET = "0.10, 0.11"
 LabelledArrays = "1.16.0"
 OrdinaryDiffEqFIRK = "2"
 SciMLBase = "3"
+Random = "1.11.0"
+SparseArrays = "1.12.0"
+StatsBase = "0.34.11"
 Test = "1.10"
 TestItemRunner = "1.1.0"
 julia = "1.10"
@@ -27,8 +30,11 @@ BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 CellMetabolism = "d7c5e2dd-9163-4219-82bc-37cddd708ca9"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 OrdinaryDiffEqFIRK = "5960d6e9-dd7a-4743-88e7-cf307b64f125"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
 
 [targets]
-test = ["Aqua", "JET", "Test", "TestItemRunner", "BenchmarkTools", "OrdinaryDiffEqFIRK", "CellMetabolism"]
+test = ["Aqua", "JET", "Test", "TestItemRunner", "BenchmarkTools", "OrdinaryDiffEqFIRK", "CellMetabolism", "Random", "SparseArrays", "StatsBase"]

--- a/src/CellMetabolismBase.jl
+++ b/src/CellMetabolismBase.jl
@@ -25,6 +25,7 @@ export disequilibrium_ratios
 
 #Accessor functions for Enzyme and MetabolicPathway types
 export stoichiometric_matrix
+export conserved_moieties
 export name
 export enzymes
 export substrates

--- a/src/MetabolicPathway_and_Enzyme_types_and_related_functions.jl
+++ b/src/MetabolicPathway_and_Enzyme_types_and_related_functions.jl
@@ -421,6 +421,46 @@ function _find_best_column(dots_matrix, remaining_cols)
 end
 
 """
+Helper to find the matrix of minimal conserved moieties. If pool A is a subset of pool B,
+then B is not minimal and is removed.
+"""
+function _find_minimal_conserved_moieties(R)
+    num_rows = size(R, 1)
+
+    # Base cases: 0 or 1 row means it's already minimal
+    if num_rows <= 1
+        return R
+    end
+
+    # Get the indeces and sizes of each candidate moiety
+    candidate_moieties = [BitSet(findall(!=(0), row)) for row in eachrow(R)]
+    sizes = [length(i) for i in candidate_moieties]
+
+    # Sort rows by their support size (smallest first)
+    p_sort = sortperm(sizes)
+    R = R[p_sort, :]
+    candidate_moieties = candidate_moieties[p_sort]
+
+    keep = trues(num_rows)
+    for i = 1:num_rows
+        if !keep[i] # if already false continue to the next
+            continue
+        end
+        for k = (i+1):num_rows
+            if !keep[k] # if already false continue to the next
+                continue
+            end
+            # If candidate_moiety i is a subset of candidate_moiety k, then
+            # k is not minimal and is discarded
+            if issubset(candidate_moieties[i], candidate_moieties[k])
+                keep[k] = false
+            end
+        end
+    end
+    return R[keep, :]
+end
+
+"""
 Computes the strictly positive left null space of a stoichiometric matrix `S`.
 Mathematically, it solves for all vectors R >= 0 such that R * S = 0. Each row in the
 returned matrix R represents an "extreme ray", which physically corresponds to a
@@ -499,34 +539,7 @@ function _fourier_motzkin(S)
             R = R[keep_nonzeros, :]
             num_rows = size(R, 1)
 
-            if num_rows > 1
-                # Get the indeces and sizes of each candidate moiety
-                candidate_moieties = [BitSet(findall(!=(0), row)) for row in eachrow(R)]
-                sizes = [length(i) for i in candidate_moieties]
-
-                # Sort rows by their support size (smallest first)
-                p_sort = sortperm(sizes)
-                R = R[p_sort, :]
-                candidate_moieties = candidate_moieties[p_sort]
-
-                keep = trues(num_rows)
-                for i = 1:num_rows
-                    if !keep[i] # if already false continue to the next
-                        continue
-                    end
-                    for k = (i+1):num_rows
-                        if !keep[k] # if already false continue to the next
-                            continue
-                        end
-                        # If candidate_moiety i is a subset of candidate_moiety k, then
-                        # k is not minimal and is discarded
-                        if issubset(candidate_moieties[i], candidate_moieties[k])
-                            keep[k] = false
-                        end
-                    end
-                end
-                R = R[keep, :]
-            end
+            R = _find_minimal_conserved_moieties(R)
         end
     end
     # After eliminating all columns (reactions), the remaining rows in R satisfy both

--- a/src/MetabolicPathway_and_Enzyme_types_and_related_functions.jl
+++ b/src/MetabolicPathway_and_Enzyme_types_and_related_functions.jl
@@ -1,4 +1,4 @@
-using LabelledArrays
+using LabelledArrays, LinearAlgebra
 
 """
     MetabolicPathway{ConstantMetabolites,Enzymes}
@@ -382,4 +382,193 @@ to enzymes ordered as in `reactants(pathway)` and `enzymes(pathway)`.
         end
     end
     return s_matrix
+end
+
+"""
+Heuristic for Dynamic Column Ordering in Fourier-Motzkin Elimination.
+
+Instead of eliminating columns in a fixed order, this function calculates a
+"cost" for eliminating each remaining column. The cost estimates the net change
+in the number of rows: (number of new rows created) - (number of old rows destroyed).
+
+By choosing the column that minimizes this localized row growth, we drastically
+delay or entirely avoid the combinatorial explosion typical of this algorithm.
+"""
+function _find_best_column(dots_matrix, remaining_cols)
+    best_col = -1
+    min_cost = typemax(Int) # Initialize with the largest possible integer
+
+    for j in remaining_cols
+        col_values = dots_matrix[:, j]
+
+        # Count how many rows have strictly positive vs strictly negative entries
+        # in the current column being evaluated.
+        num_pos = count(>(0), col_values)
+        num_neg = count(<(0), col_values)
+
+        # Linear combinations will happen between every positive and negative pair:
+        # New rows generated = num_pos * num_neg
+        # Old rows eliminated = num_pos + num_neg
+        cost = (num_pos * num_neg) - (num_pos + num_neg)
+
+        # Track the column that minimizes this row-growth metric
+        if cost < min_cost
+            min_cost = cost
+            best_col = j
+        end
+    end
+    return best_col
+end
+
+"""
+Computes the strictly positive left null space of a stoichiometric matrix `S`.
+Mathematically, it solves for all vectors R >= 0 such that R * S = 0. Each row in the
+returned matrix R represents an "extreme ray", which physically corresponds to a
+conservation relation (conserved moiety pool) in the metabolic network. This algorithm is
+explained in more detail in Schuster and Hilgetag 1995, and Schuster and Höfer 1991.
+
+References
+    Schuster, Stefan, and Claus Hilgetag. "What information about the conserved-moiety
+    structure of chemical reaction systems can be derived from their stoichiometry?." The
+    Journal of Physical Chemistry 99.20 (1995): 8017-8023.
+
+    Schuster, Stefan, and Thomas Höfer. "Determining all extreme semi-positive conservation
+    relations in chemical reaction systems: a test criterion for conservativity." Journal
+    of the Chemical Society, Faraday Transactions 87.16 (1991): 2561-2566.
+"""
+function _fourier_motzkin(S)
+    m, n = size(S)
+
+    # STEP 1: Initialize R as an Identity Matrix.
+    # This represents the strictly positive orthant (R >= 0).
+    # Every metabolite starts as its own independent pool with a coefficient of 1.
+    R = Matrix{BigInt}(I, m, m)
+
+    remaining_cols = collect(1:n)
+
+    while !isempty(remaining_cols)
+        current_dots = R * S[:, remaining_cols]
+
+        # Find the best reaction to process
+        best_idx = _find_best_column(current_dots, 1:length(remaining_cols))
+
+        # Get the index and value of the reaction being processed in the current loop
+        j = remaining_cols[best_idx]
+        v = S[:, j]
+        # Delete the current reaction from the remaining reactions
+        deleteat!(remaining_cols, best_idx)
+
+        # STEP 2: Evaluate the reaction's effect on current pools (R * v).
+        # > 0 means the pool grows (produced by reaction)
+        # < 0 means the pool shrinks (consumed by reaction)
+        # == 0 means the pool is conserved (unaffected by reaction)
+        dots = R * v
+        pos_rays = findall(>(0), dots)
+        neg_rays = findall(<(0), dots)
+        zero_rays = findall(==(0), dots)
+
+        # STEP 3: Keep the pools that are already conserved.
+        # These vectors already satisfy R * v = 0 for this specific reaction.
+        new_R = R[zero_rays, :]
+
+        # STEP 4: Combine growing and shrinking pools to create new conserved pools.
+        # By cross-multiplying, we perfectly cancel out the reaction's effect,
+        # forcing the new combinations to satisfy R * v = 0.
+        # Because we only ever add positive vectors together, R strictly remains >= 0.
+        for pos in pos_rays
+            for neg in neg_rays
+                r_new = dots[pos] * R[neg, :] - dots[neg] * R[pos, :]
+
+                # Simplify the pool's coefficients (e.g. 2A + 2B -> 1A + 1B)
+                row_gcd = reduce(gcd, r_new)
+                if row_gcd > 1
+                    r_new .÷= row_gcd
+                end
+
+                new_R = vcat(new_R, r_new')
+            end
+        end
+
+        R = new_R
+        num_rows = size(R, 1)
+
+        # STEP 5: Keep only the fundamental building blocks (Extreme Rays).
+        if num_rows > 0
+            # Remove entirely empty pools
+            keep_nonzeros = [any(!=(0), row) for row in eachrow(R)]
+            R = R[keep_nonzeros, :]
+            num_rows = size(R, 1)
+
+            if num_rows > 1
+                # Get the indeces and sizes of each candidate moiety
+                candidate_moieties = [BitSet(findall(!=(0), row)) for row in eachrow(R)]
+                sizes = [length(i) for i in candidate_moieties]
+
+                # Sort rows by their support size (smallest first)
+                p_sort = sortperm(sizes)
+                R = R[p_sort, :]
+                candidate_moieties = candidate_moieties[p_sort]
+
+                keep = trues(num_rows)
+                for i = 1:num_rows
+                    if !keep[i] # if already false continue to the next
+                        continue
+                    end
+                    for k = (i+1):num_rows
+                        if !keep[k] # if already false continue to the next
+                            continue
+                        end
+                        # If candidate_moiety i is a subset of candidate_moiety k, then
+                        # k is not minimal and is discarded
+                        if issubset(candidate_moieties[i], candidate_moieties[k])
+                            keep[k] = false
+                        end
+                    end
+                end
+                R = R[keep, :]
+            end
+        end
+    end
+    # After eliminating all columns (reactions), the remaining rows in R satisfy both
+    # R >= 0 and R * S = 0 for the entire matrix.
+    return R
+end
+
+"""
+    conserved_moieties(pathway::MetabolicPathway)
+
+Uses a Fourier-Motzkin Elimination algorithm to return the conserved moieties of the
+metabolic pathway. The sum of each of these conserved moieties remains constant throughout
+a simulation.
+
+References
+    Schuster, Stefan, and Claus Hilgetag. "What information about the conserved-moiety
+    structure of chemical reaction systems can be derived from their stoichiometry?." The
+    Journal of Physical Chemistry 99.20 (1995): 8017-8023.
+
+    Schuster, Stefan, and Thomas Höfer. "Determining all extreme semi-positive conservation
+    relations in chemical reaction systems: a test criterion for conservativity." Journal
+    of the Chemical Society, Faraday Transactions 87.16 (1991): 2561-2566.
+"""
+@generated function conserved_moieties(
+    ::MetabolicPathway{ConstMetabs,Enzs},
+) where {ConstMetabs,Enzs}
+    metabolites = reactants(MetabolicPathway{ConstMetabs,Enzs}())
+    S = stoichiometric_matrix(MetabolicPathway{ConstMetabs,Enzs}())
+    R = _fourier_motzkin(S)
+    @assert iszero(R * S) "Conserved moieties must be in the left nullspace of S."
+    @assert all(R .>= 0) "Conserved moieties must be all be positive."
+
+    conserved_moieties = String[]
+    for (i, row) in enumerate(eachrow(R))
+        terms = String[]
+        for (j, value) in enumerate(row)
+            if value != 0
+                push!(terms, "$(value)⋅$(metabolites[j])")
+            end
+        end
+        push!(conserved_moieties, "$i: " * join(terms, " + "))
+    end
+    conserved_moieties_string = join(conserved_moieties, "\n")
+    return conserved_moieties_string
 end

--- a/test/tests_MetabolicPathway_and_Enzyme_types_and_related_functions.jl
+++ b/test/tests_MetabolicPathway_and_Enzyme_types_and_related_functions.jl
@@ -387,3 +387,308 @@ end
     end
 end
 
+@testitem "Conserved Moieties Tests" setup = [GenerateRandomStoichiometricMatrix] begin
+    @testset "Fourier-Motzkin Fundamentals" begin
+        # Test 10 random stoichiometric matrices to ensure fundamental checks pass
+        i = 1
+        number_of_tests = 10
+
+        # Store the results of each test
+        nullspace_test_results = Bool[]
+        positive_test_results = Bool[]
+        metabolites_present_result = Bool[]
+        non_zero_moieties_result = Bool[]
+        simplest_form_result = Bool[]
+        minimal_pools_result = Bool[]
+
+        keep_testing = true
+        while keep_testing
+            reactions = rand(1:100)
+            # 1.3 times more metabolites than reactions (similar to Glycolysis and TCA cycle)
+            metabolites = round(Int, 1.31 * reactions)
+            random_matrix = generate_random_stoichiometric_matrix(metabolites, reactions)
+            R_random = CellMetabolismBase._fourier_motzkin(random_matrix)
+
+            # Test 1: The solution is the left null space of the stoichiometric matrix
+            push!(nullspace_test_results, iszero(R_random * random_matrix))
+
+            # Test 2: There are no negative values in the matrix of conserved moieties
+            push!(positive_test_results, all(R_random .>= 0))
+
+            # Test 3: All metabolites in the stoichiometric matrix are present in the
+            # conserved moieties matrix
+            push!(metabolites_present_result, size(R_random, 2) == metabolites)
+
+            for row_i in eachrow(R_random)
+
+                # Test 4: No conserved moiety is entirely zero
+                push!(non_zero_moieties_result, !iszero(row_i))
+
+                # Test 5: Each conserved moiety should be in its simplest form, so the
+                # greatest common divisor should be equal to 1
+                push!(simplest_form_result, gcd(row_i) == 1)
+                for row_j in eachrow(R_random)
+                    if row_i != row_j
+
+                        # Test 6. None of the conserved moieties should be a subset of
+                        # another conserved moiety
+                        push!(
+                            minimal_pools_result,
+                            !issubset(
+                                findall(x -> x != 0, row_i),
+                                findall(x -> x != 0, row_j),
+                            ),
+                        )
+                    end
+                end
+            end
+            if i == number_of_tests
+                keep_testing = false
+            end
+            i += 1
+        end
+
+        @test all(nullspace_test_results)
+        @test all(positive_test_results)
+        @test all(metabolites_present_result)
+        @test all(non_zero_moieties_result)
+        @test all(simplest_form_result)
+        @test all(minimal_pools_result)
+    end
+
+    @testset "_find_best_column returns the best reaction to process next" begin
+        # Reactions
+        # 1: ATP + B + C ⇾ D + E + ADP
+        # 2: ATP + D + E ⇾ F + G + ADP + H
+        # 3: I ⇾ J
+        # 4: K ⇾ L
+
+        # Costs
+        # Cost formula: (num_pos * num_neg) - (num_pos + num_neg)
+        # 1: 3*3 - (3+3) = 9 - 6 = 3
+        # 2: 3*4 - (3+4) = 12 - 7 = 5
+        # 3: 1*1 - (1-1) = 0
+        # 4: 1*1 - (1-1) = 0
+        S = [
+            -1 -1 0 0 # ATP
+            -1 0 0 0 # B
+            -1 0 0 0 # C
+            1 -1 0 0 # D
+            1 -1 0 0 # E
+            0 1 0 0 # F
+            0 1 0 0 # G
+            1 1 0 0 # ADP
+            0 1 0 0 # H
+            0 0 1 0 # I
+            0 0 -1 0 # J
+            0 0 0 1 # K
+            0 0 0 -1 # L
+        ]
+
+        @testset "Combinatorial explosion prevention" begin
+            # Since ATP and ADP are involved in reactions 1 and 2, the best reaction to
+            # process first is 3 because it will cause the least combinatorial explosion of
+            # terms and it appears before reaction 4 (which has the same cost)
+            best_idx = CellMetabolismBase._find_best_column(S, 1:4)
+            @test best_idx == 3
+        end
+
+        @testset "Tie breaker behaviour" begin
+            # If evaluated on [3, 4], both have cost 0.
+            # The algorithm strictly uses `< min_cost`, so it returns the first evaluated.
+            @test CellMetabolismBase._find_best_column(S, [3, 4]) == 3
+            @test CellMetabolismBase._find_best_column(S, [4, 3]) == 4
+        end
+
+        @testset "Subset of remaining columns" begin
+            # If column 3 is removed, it should evaluate [1, 2, 4]
+            # Costs are: C1 => 3, C2 => 5, C4 => 0. Best is C4.
+            @test CellMetabolismBase._find_best_column(S, [1, 2, 4]) == 4
+
+            # If column 3 and 4 are removed, it should evaluate [1, 2]
+            # Costs are: C1 => 3, C2 => 5. Best is C1.
+            @test CellMetabolismBase._find_best_column(S, [1, 2]) == 1
+        end
+
+        @testset "Empty remaining columns" begin
+            # The function initializes `best_col` to -1.
+            # If passed an empty list, it should return -1 safely without bounds errors.
+            @test CellMetabolismBase._find_best_column(S, Int[]) == -1
+        end
+    end
+
+    @testset "Toy networks tests" begin
+        @testset "Simple conversion: 2A -> 2B" begin
+            S1 = [
+                -2; 2;;
+            ]
+            R1 = CellMetabolismBase._fourier_motzkin(S1)
+            @test size(R1, 1) == 1 # 1 conserved pool
+            @test size(R1, 2) == 2 # 2 metabolites
+            # The pool should be 1*A + 1*B
+            @test R1[1, 1] == R1[1, 2] && R1[1, :] == [1, 1]
+            @test iszero(R1 * S1)
+            @test all(R1 .>= 0)
+        end
+
+        @testset "Linear Chain: A -> B -> C" begin
+            S2 = [
+                -1 0
+                1 -1
+                0 1
+            ]
+            R2 = CellMetabolismBase._fourier_motzkin(S2)
+            @test size(R2, 1) == 1 # 1 conserved pool
+            @test size(R2, 2) == 3 # 3 metabolites
+            # The pool should be 1*A + 1*B + 1*C
+            @test R2[1, 1] == R2[1, 2] == R2[1, 3] && R2[1, :] == [1, 1, 1]
+            @test iszero(R2 * S2)
+            @test all(R2 .>= 0)
+        end
+
+        @testset "Open System: -> A ->" begin
+            S3 = [
+                1 -1
+            ]
+            R3 = CellMetabolismBase._fourier_motzkin(S3)
+            @test size(R3, 1) == 0 # 0 conserved pools (nothing is conserved)
+            @test size(R3, 2) == 1 # 1 metabolite
+            @test iszero(R3 * S3)
+        end
+
+        @testset "Disconnected metabolites" begin
+            S4 = [
+                0; 0;;
+            ]
+            R4 = CellMetabolismBase._fourier_motzkin(S4)
+            # 2 conserved pools (each metabolite independently)
+            @test size(R4, 1) == 2 # 2 conserved pools
+            @test size(R4, 2) == 2 # 2 metabolites
+            @test R4[1, :] == [1, 0] && R4[2, :] == [0, 1]
+            @test iszero(R4 * S4)
+            @test all(R4 .>= 0)
+        end
+
+        @testset "Closed Loop: A → B → C → A" begin
+            S5 = [
+                -1 0 1
+                1 -1 0
+                0 1 -1
+            ]
+            R5 = CellMetabolismBase._fourier_motzkin(S5)
+            # One conserved moiety (1*A + 1*B + 1*C) due to pathway using and making A
+            @test size(R5, 1) == 1
+            @test size(R5, 2) == 3 # 3 metabolites
+            @test R5[1, :] == [1, 1, 1]
+            @test iszero(R5 * S5)
+            @test all(R5 .>= 0)
+        end
+
+        @testset "Carrier Cofactor: A + ATP → B + ADP" begin
+            S6 = [
+                -1; -1; 1; 1;;
+            ]
+            R6 = CellMetabolismBase._fourier_motzkin(S6)
+            # Four conserved pools: 1*A + 1*B, 1*B + 1*ATP, 1*A + 1*ADP, 1*B + 1*ATP
+            @test size(R6, 1) == 4
+            @test size(R6, 2) == 4 # 4 metabolites
+            # 1*A + 1*B
+            @test R6[1, 1] == R6[1, 3] && R6[1, :] == [1, 0, 1, 0]
+            # 1*B + 1*ATP
+            @test R6[2, 2] == R6[2, 3] && R6[2, :] == [0, 1, 1, 0]
+            # 1*A + 1*ADP
+            @test R6[3, 1] == R6[3, 4] && R6[3, :] == [1, 0, 0, 1]
+            # 1*ATP + 1*ADP
+            @test R6[4, 2] == R6[4, 4] && R6[4, :] == [0, 1, 0, 1]
+            @test iszero(R6 * S6)
+            @test all(R6 .>= 0)
+        end
+
+        @testset "Branched Pathway: A → B, A → C" begin
+            S7 = [
+                -1 -1
+                1 0
+                0 1
+            ]
+            R7 = CellMetabolismBase._fourier_motzkin(S7)
+            # One conserved pool (1*A + 1*B + 1*C)
+            @test size(R7, 1) == 1
+            @test size(R7, 2) == 3 # 3 metabolites
+            @test R7[1, 1] == R7[1, 2] == R7[1, 3] && R7[1, :] == [1, 1, 1]
+            @test iszero(R7 * S7)
+            @test all(R7 .>= 0)
+        end
+
+        @testset "Disconnected pathways: A → B → C, D → E → F" begin
+            S8 = [
+                -1 0 0 0
+                1 -1 0 0
+                0 1 0 0
+                0 0 -1 0
+                0 0 1 -1
+                0 0 0 1
+            ]
+            R8 = CellMetabolismBase._fourier_motzkin(S8)
+
+            # Two conserved pools: 1*A + 1*B + 1*C and 1*D + 1*E + 1*F
+            @test size(R8, 1) == 2
+            @test size(R8, 2) == 6 # 6 metabolites
+            @test R8[1, 1] == R8[1, 2] == R8[1, 3] && R8[1, :] == [1, 1, 1, 0, 0, 0]
+            @test R8[2, 4] == R8[2, 5] == R8[2, 6] && R8[2, :] == [0, 0, 0, 1, 1, 1]
+
+            @test iszero(R8 * S8)
+            @test all(R8 .>= 0)
+        end
+
+        @testset "Different stoichiometries: 1A + 2B ⇾ 2C" begin
+            S9 = [
+                -1; -2; 2;;
+            ]
+            R9 = CellMetabolismBase._fourier_motzkin(S9)
+            # Two conserved pools: 2*A + 1*C and 1*B + 1*C
+            @test size(R9, 1) == 2
+            @test size(R9, 2) == 3 # 3 metabolites
+            @test R9[1, 1] == R9[1, 3] * 2 && R9[2, 2] == R9[2, 3]
+            @test R9[1, :] == [2, 0, 1] && R9[2, :] == [0, 1, 1]
+            @test iszero(R9 * S9)
+            @test all(R9 .>= 0)
+        end
+    end
+
+    @testset "conserved_moieties is correct for a known pathway" begin
+        glycolysis_pathway = MetabolicPathway(
+            (:Glucose_media, :Lactate_media),
+            (
+                (:GLUT, (:Glucose_media,), (:Glucose,)),
+                (:HK1, (:Glucose, :ATP), (:G6P, :ADP)),
+                (:GPI, (:G6P,), (:F6P,)),
+                (:PFKP, (:F6P, :ATP), (:F16BP, :ADP)),
+                (:ALDO, (:F16BP,), (:GAP, :DHAP)),
+                (:TPI, (:DHAP,), (:GAP,)),
+                (:GAPDH, (:GAP, :Pi, :NAD), (:BPG, :NADH)),
+                (:PGK, (:BPG, :ADP), (:Three_PG, :ATP)),
+                (:PGM, (:Three_PG,), (:Two_PG,)),
+                (:ENO, (:Two_PG,), (:PEP,)),
+                (:PKM, (:PEP, :ADP), (:Pyruvate, :ATP)),
+                (:LDH, (:Pyruvate, :NADH), (:Lactate, :NAD)),
+                (:MCT, (:Lactate,), (:Lactate_media,)),
+                (:ATPase, (:ATP,), (:ADP, :Pi)),
+                (:AK, (:ADP, :ADP), (:ATP, :AMP)),
+            ),
+        )
+        expected_glycolysis_conserved_moieties = join(
+            [
+                "1: 1⋅Glucose_media",
+                "2: 1⋅Lactate_media",
+                "3: 1⋅NAD + 1⋅NADH",
+                "4: 1⋅ATP + 1⋅ADP + 1⋅AMP",
+                "5: 1⋅NAD + 1⋅BPG + 1⋅Three_PG + 1⋅Two_PG + 1⋅PEP + 1⋅Pyruvate",
+                "6: 2⋅ATP + 1⋅G6P + 1⋅ADP + 1⋅F6P + 2⋅F16BP + 1⋅GAP + 1⋅DHAP + 1⋅Pi + " *
+                "2⋅BPG + 1⋅Three_PG + 1⋅Two_PG + 1⋅PEP",
+            ],
+            "\n",
+        )
+        glycolysis_conserved_moieties = conserved_moieties(glycolysis_pathway)
+        @test glycolysis_conserved_moieties == expected_glycolysis_conserved_moieties
+    end
+end

--- a/test/tests_MetabolicPathway_and_Enzyme_types_and_related_functions.jl
+++ b/test/tests_MetabolicPathway_and_Enzyme_types_and_related_functions.jl
@@ -249,3 +249,141 @@ end
     @test neutral_params.Custom_L == 0.0
     @test neutral_params.Custom_bias == 0.0
 end
+
+@testsnippet GenerateRandomStoichiometricMatrix begin
+    using SparseArrays, Distributions, StatsBase, Random
+
+    """
+    Helper to calculate the probability weights that determine the number of reactions a
+    metabolite is involved in according to a power law.
+    """
+    function get_powerlaw_weights(m::Int, alpha::Float64)
+        return [1.0 / (i^alpha) for i = 1:m]
+    end
+
+    """
+    Helper to generate a random stoichiometric matrix that has a scale-free network topology
+    (Jeon et. al. 2000). Each reaction has a minimum of 2 participants and an average of
+    `avg_participants`. 90% of the coefficients in the network are -1 or 1, 10% of the
+    coefficients are -2 or 2. The steepness of the power law that defines the scale-free
+    network is set by `alpha` (default value matches finding of Jeon et. al. 2000).
+
+    References
+        Jeong, Hawoong, et al. "The large-scale organization of metabolic networks." Nature
+        407.6804 (2000): 651-654.
+    """
+    function generate_random_stoichiometric_matrix(
+        m::Int,
+        n::Int;
+        avg_participants::Float64 = 4.0,
+        alpha::Float64 = 0.833334,
+    )
+        weights = get_powerlaw_weights(m, alpha)
+
+        # Construct vector of weight values
+        prob_weights = Weights(weights)
+
+        # Shuffle the indices so the mega-hubs aren't always rows 1, 2, and 3
+        metabolite_ids = randperm(m)
+
+        I = Int[] # row index
+        J = Int[] # column index
+        V = Int[] # value
+
+        rxn_size_dist = Poisson(avg_participants - 2.0)
+
+        for j = 1:n
+            num_participants = min(m, 2.0 + rand(rxn_size_dist))
+
+            participants = Set{Int}()
+            while length(participants) < num_participants
+                # Draw a metabolite strictly according to the Power Law
+                chosen_index = sample(metabolite_ids, prob_weights)
+                push!(participants, chosen_index)
+            end
+
+            for i in participants
+                coeff = rand() < 0.9 ? rand([-1, 1]) : rand([-2, 2])
+                push!(I, i), push!(J, j), push!(V, coeff)
+            end
+        end
+
+        return sparse(I, J, V, m, n)
+    end
+end
+
+@testitem "Random stoichiometric matrix generation" setup =
+    [GenerateRandomStoichiometricMatrix] begin
+    using Random
+
+    # Create a random matrix for all following tests
+    m = rand(10:50)
+    n = rand(10:50)
+    random_S = generate_random_stoichiometric_matrix(m, n)
+
+    @testset "The dimensions and type are correct" begin
+        @test size(random_S, 1) == m && size(random_S, 2) == n
+        @test random_S isa SparseMatrixCSC
+    end
+
+    @testset "The desity of the matrix is determined by the `avg_participants`" begin
+        avg_participants = 4.0
+        expected_density = avg_participants / m
+        actual_density = nnz(random_S) / (m * n)
+        @test isapprox(expected_density, actual_density, rtol = 0.1)
+    end
+
+    @testset "Coefficient values must only be -2, -1, 1, or 2" begin
+        valid_coeffs = Set([-2, -1, 1, 2])
+        @test all(v -> v in valid_coeffs, nonzeros(random_S))
+    end
+
+    @testset "Reaction sizes should be ≥ 2 or ≤ `m`" begin
+        # Get the number of non-zeros in each column
+        col_participant_counts = diff(random_S.colptr)
+        @test minimum(col_participant_counts) >= 2
+        @test maximum(col_participant_counts) <= m
+    end
+
+    @testset "Scale-free network topology" begin
+        # In a scale-free network, mega-hub metabolites should be involved in many more
+        # reactions than the median. In a normal/Poisson network, the metabolite involved
+        # in the maximum number of reactions is usually close to the median
+        Random.seed!(42)
+        S = generate_random_stoichiometric_matrix(1000, 5000)
+
+        # Get degrees of all metabolites
+        row_degrees = zeros(Int, 1000)
+        for r in rowvals(S)
+            row_degrees[r] += 1
+        end
+
+        max_degree = maximum(row_degrees)
+        median_degree = median(row_degrees)
+
+        @test max_degree > (median_degree * 10)
+    end
+
+    @testset "Power Law Weight Generation" begin
+        m = 5
+        alpha = 0.8333
+
+        # Generate the weights
+        weights = get_powerlaw_weights(m, alpha)
+
+        # 1. The first weight should always be exactly 1.0 (1 / 1^alpha)
+        @test weights[1] == 1.0
+
+        # 2. Check the mathematical decline of the weights
+        # For element 2, weight should be 1 / (2^0.8333) ≈ 0.56123
+        @test isapprox(weights[2], 1.0 / (2^alpha), atol = 1e-5)
+
+        # For element 5, weight should be 1 / (5^0.8333) ≈ 0.26116
+        @test isapprox(weights[5], 1.0 / (5^alpha), atol = 1e-5)
+
+        # 3. Ensure all weights are strictly positive and descending
+        @test all(weights .> 0)
+        @test issorted(weights, rev = true)
+    end
+end
+

--- a/test/tests_MetabolicPathway_and_Enzyme_types_and_related_functions.jl
+++ b/test/tests_MetabolicPathway_and_Enzyme_types_and_related_functions.jl
@@ -315,6 +315,7 @@ end
 @testitem "Random stoichiometric matrix generation" setup =
     [GenerateRandomStoichiometricMatrix] begin
     using Random
+    Random.seed!(42)
 
     # Create a random matrix for all following tests
     m = rand(10:50)
@@ -330,7 +331,7 @@ end
         avg_participants = 4.0
         expected_density = avg_participants / m
         actual_density = nnz(random_S) / (m * n)
-        @test isapprox(expected_density, actual_density, rtol = 0.1)
+        @test isapprox(expected_density, actual_density, rtol = 0.3)
     end
 
     @testset "Coefficient values must only be -2, -1, 1, or 2" begin
@@ -349,7 +350,6 @@ end
         # In a scale-free network, mega-hub metabolites should be involved in many more
         # reactions than the median. In a normal/Poisson network, the metabolite involved
         # in the maximum number of reactions is usually close to the median
-        Random.seed!(42)
         S = generate_random_stoichiometric_matrix(1000, 5000)
 
         # Get degrees of all metabolites

--- a/test/tests_MetabolicPathway_and_Enzyme_types_and_related_functions.jl
+++ b/test/tests_MetabolicPathway_and_Enzyme_types_and_related_functions.jl
@@ -515,6 +515,29 @@ end
             # If passed an empty list, it should return -1 safely without bounds errors.
             @test CellMetabolismBase._find_best_column(S, Int[]) == -1
         end
+
+        @testset "_find_minimal_conserved_moieties removes non minimal moieties" begin
+            R_mock = [
+                1 1 1 0 0 # Minimal
+                1 1 1 0 1 # Not minimal, superset of first
+                0 0 0 1 0 # Minimal
+                1 1 1 1 0 # Not minimal, superset of first and third
+            ]
+            R_filtered = CellMetabolismBase._find_minimal_conserved_moieties(R_mock)
+
+            # Verify the function stripped the two superset rows
+            @test size(R_filtered, 1) == 2
+
+            # First conserved moiety is the smallest minimal pool
+            @test R_filtered[1, :] == [0, 0, 0, 1, 0]
+            # Second conserved moiety is the largest minimal pool
+            @test R_filtered[2, :] == [1, 1, 1, 0, 0]
+            # The entire minimal conserved moiety matrix is correct
+            @test R_filtered == [
+                0 0 0 1 0
+                1 1 1 0 0
+            ]
+        end
     end
 
     @testset "Toy networks tests" begin


### PR DESCRIPTION
# Description

`conserved_moieties` gets the groups of metabolites whose sum is always constant, meaning that these groups are conserved in a metabolic pathway. It uses a Fourier-Mozkin elimination algorithm to ensure that the conserved moieties returned are always positive.

Usage and output:
```
julia> glycolysis_pathway = MetabolicPathway(
           (:Glucose_media, :Lactate_media),
           (
               (:GLUT, (:Glucose_media,), (:Glucose,)),
               (:HK1, (:Glucose, :ATP), (:G6P, :ADP)),
               (:GPI, (:G6P,), (:F6P,)),
               (:PFKP, (:F6P, :ATP), (:F16BP, :ADP)),
               (:ALDO, (:F16BP,), (:GAP, :DHAP)),
               (:TPI, (:DHAP,), (:GAP,)),
               (:GAPDH, (:GAP, :Pi, :NAD), (:BPG, :NADH)),
               (:PGK, (:BPG, :ADP), (:Three_PG, :ATP)),
               (:PGM, (:Three_PG,), (:Two_PG,)),
               (:ENO, (:Two_PG,), (:PEP,)),
               (:PKM, (:PEP, :ADP), (:Pyruvate, :ATP)),
               (:LDH, (:Pyruvate, :NADH), (:Lactate, :NAD)),
               (:MCT, (:Lactate,), (:Lactate_media,)),
               (:ATPase, (:ATP,), (:ADP, :Pi)),
               (:AK, (:ADP, :ADP), (:ATP, :AMP)),
           ),
       )
julia> print(conserved_moieties(glycolysis_pathway))
1: 1⋅Glucose_media
2: 1⋅Lactate_media
3: 1⋅NAD + 1⋅NADH
4: 1⋅ATP + 1⋅ADP + 1⋅AMP
5: 1⋅NAD + 1⋅BPG + 1⋅Three_PG + 1⋅Two_PG + 1⋅PEP + 1⋅Pyruvate
6: 2⋅ATP + 1⋅G6P + 1⋅ADP + 1⋅F6P + 2⋅F16BP + 1⋅GAP + 1⋅DHAP + 1⋅Pi + 2⋅BPG + 1⋅Three_PG + 1⋅Two_PG + 1⋅PEP
```

# Tests

- Added a new function to generate random stoichiometric matrices that have a similar topology to biological networks. 
- Added tests for `conserved_moieties` and  the functions it calls to ensure that they work on: randomly generated stoichiometric matrices, toy metabolic networks and real metabolic networks where the conserved moieties are known
   - The tests ensure that the conserved moiety matrix (R) is in the left null space of the stoichiometric matrix (S) such that $R * S = 0$ and that all $R \ge 0$
- Tests always passed on the ~1000 random matrices I simulated
- The largest matrix I could run with 10GB of RAM had ~650 metabolites and ~500 reactions and ran in 34 seconds
- The new tests I added run in 3.5s