### PR TITLE
Bump to SciMLBase 3 / OrdinaryDiffEqFIRK 2 (supersedes #33, #35)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CellMetabolismBase"
 uuid = "29f58b35-15e1-4d3c-99d7-eccaac145095"
 authors = ["Denis Titov <titov@berkeley.edu>  and contributors"]
-version = "0.3.1"
+version = "0.4.0"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
@@ -11,15 +11,15 @@ SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 [compat]
 Aqua = "0.8.11"
 BenchmarkTools = "1.6"
-CellMetabolism = "0.2"
+CellMetabolism = "0.3"
 Distributions = "0.25.117"
 JET = "0.10"
 LabelledArrays = "1.16.0"
-OrdinaryDiffEqFIRK = "1.16"
-SciMLBase = "2.75.1"
+OrdinaryDiffEqFIRK = "2"
+SciMLBase = "3"
 Test = "1.10"
 TestItemRunner = "1.1.0"
-julia = "1.10, 1.11, 1.12"
+julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
@@ -32,3 +32,8 @@ TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
 
 [targets]
 test = ["Aqua", "JET", "Test", "TestItemRunner", "BenchmarkTools", "OrdinaryDiffEqFIRK", "CellMetabolism"]
+
+# TEMPORARY: the registered CellMetabolism caps CellMetabolismBase at <0.4, so its
+# updated branch is needed to test against this release. Remove before registering.
+[sources]
+CellMetabolism = {url = "https://github.com/DenisTitovLab/CellMetabolism.jl", rev = "bump-ordinarydiffeq-v7"}

--- a/Project.toml
+++ b/Project.toml
@@ -32,8 +32,3 @@ TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
 
 [targets]
 test = ["Aqua", "JET", "Test", "TestItemRunner", "BenchmarkTools", "OrdinaryDiffEqFIRK", "CellMetabolism"]
-
-# TEMPORARY: the registered CellMetabolism caps CellMetabolismBase at <0.4, so its
-# updated branch is needed to test against this release. Remove before registering.
-[sources]
-CellMetabolism = {url = "https://github.com/DenisTitovLab/CellMetabolism.jl", rev = "bump-ordinarydiffeq-v7"}

--- a/src/make_EnsembleProblem.jl
+++ b/src/make_EnsembleProblem.jl
@@ -50,7 +50,8 @@ function make_EnsembleProblem(
 
     length(vect_init_cond) == length(vect_params) || error("vect_init_cond and vect_params must have the same length")
     prob = make_ODEProblem(metab_path, vect_init_cond[1], tspan, vect_params[1])
-    function prob_func(prob, i, repeat)
+    function prob_func(prob, ctx)
+        i = ctx.sim_id
         @. prob.u0 = vect_init_cond[i]
         @. prob.p = vect_params[i]
         return prob

--- a/test/test_CellMetabolism_compat.jl
+++ b/test/test_CellMetabolism_compat.jl
@@ -51,6 +51,6 @@ end
         reltol = 1e-8,
     )
 
-    @test length(sols) == length(init_ensemble)
-    @test all(sol.retcode == SciMLBase.ReturnCode.Success for sol in sols)
+    @test length(sols.u) == length(init_ensemble)
+    @test all(sol.retcode == SciMLBase.ReturnCode.Success for sol in sols.u)
 end

--- a/test/tests_make_EnsembleProblem.jl
+++ b/test/tests_make_EnsembleProblem.jl
@@ -61,7 +61,7 @@
         reltol = 1e-8,
         trajectories = 2,
     )
-    @test length(sol) == 2
+    @test length(sol.u) == 2
 
     # Check that the solutions are different (used different params/init conditions)
     @test sol.u[1].u[end] != sol.u[2].u[end]
@@ -79,7 +79,7 @@
         reltol = 1e-8,
         trajectories = 2,
     )
-    @test length(sol) == 2
+    @test length(sol.u) == 2
 
     # Solutions should differ due to different initial conditions
     @test sol.u[1].u[1] != sol.u[2].u[1]
@@ -97,7 +97,7 @@
         reltol = 1e-8,
         trajectories = 2,
     )
-    @test length(sol) == 2
+    @test length(sol.u) == 2
 
     # Solutions should differ due to different parameters
     @test sol.u[1].u[end] != sol.u[2].u[end]
@@ -170,7 +170,7 @@
         reltol = 1e-8,
         trajectories = n_bootstraps,
     )
-    @test length(sol) == n_bootstraps
+    @test length(sol.u) == n_bootstraps
 
     # Check that the solutions vary (due to different random samples)
     final_vals = [s.u[end][4] for s in sol.u]  # Get final values for metabolite C
@@ -194,7 +194,7 @@
 
     # Check a few samples
     for i = 1:5
-        new_prob = prob_func(base_prob, i, 1)
+        new_prob = prob_func(base_prob, (; sim_id = i))
 
         # Test initial conditions are within reasonable bounds
         # For normal distributions, most values should be within 3 std devs
@@ -233,7 +233,7 @@
         reltol = 1e-8,
         trajectories = n_bootstraps,
     )
-    @test length(sol) == n_bootstraps
+    @test length(sol.u) == n_bootstraps
 
     # Check that the solutions vary due to different initial conditions
     initial_vals = [s.u[1][2] for s in sol.u]  # Get initial values for metabolite A
@@ -243,7 +243,7 @@
     prob_func = ensemble_prob.prob_func
     base_prob = ensemble_prob.prob
     for i = 1:5
-        new_prob = prob_func(base_prob, i, 1)
+        new_prob = prob_func(base_prob, (; sim_id = i))
         @test new_prob.p == params1  # Parameters should remain fixed
     end
 
@@ -266,7 +266,7 @@
         reltol = 1e-8,
         trajectories = n_bootstraps,
     )
-    @test length(sol) == n_bootstraps
+    @test length(sol.u) == n_bootstraps
 
     # Check that the solutions vary due to different parameters
     final_vals = [s.u[end][5] for s in sol.u]  # Get final values for metabolite D
@@ -276,7 +276,7 @@
     prob_func = ensemble_prob.prob_func
     base_prob = ensemble_prob.prob
     for i = 1:5
-        new_prob = prob_func(base_prob, i, 1)
+        new_prob = prob_func(base_prob, (; sim_id = i))
         @test new_prob.u0 == init_cond1  # Initial conditions should remain fixed
     end
 end


### PR DESCRIPTION
## Why

CompatHelper opened #33 (SciMLBase → 3) and #35 (OrdinaryDiffEqFIRK → 2) separately, and **neither can resolve on its own**. `SciMLBase 3`, `OrdinaryDiffEqFIRK 2` and `RecursiveArrayTools 4` are a coupled set — bumping one without the others is unsatisfiable. This PR bumps them together and supersedes both.

## Changes

**Compat** (`Project.toml`)
- `SciMLBase = "3"`, `OrdinaryDiffEqFIRK = "2"` (forward-only — drops SciMLBase 2 / FIRK 1)
- `CellMetabolism = "0.3"` (the test dep; 0.2.x caps this package at <0.4)
- `julia = "1.10"` — keeps the LTS floor and stops the enumerated `1.10, 1.11, 1.12` from excluding 1.13+
- version → **0.4.0** (dropping SciMLBase 2 support is breaking for downstream)

**Code (new-API fixes)**
- `src/make_EnsembleProblem.jl`: ensemble `prob_func` now takes `(prob, ctx)` and reads `ctx.sim_id`. SciMLBase v3 calls the 2-arg form; the old `(prob, i, repeat)` is no longer invoked.
- tests: under RecursiveArrayTools 4 `EnsembleSolution` subtypes `AbstractArray`, so `length(sol)` / iterating `sol` now operate on flattened scalar elements. Switched to `sol.u` for per-trajectory access. (`sol.retcode`, per-timestep `sol.u[i].u[end]`, `RadauIIA9/5`, validate are all unaffected.)

Full suite is green locally on SciMLBase 3.21 / FIRK 2.3 / RecursiveArrayTools 4.3 (Julia 1.12).

## Rollout note

`CellMetabolism` (a test dep) and this package depend on each other, so there's a circular bump. The temporary `[sources]` entry points the test dep at the matching [`CellMetabolism#bump-ordinarydiffeq-v7`](https://github.com/DenisTitovLab/CellMetabolism.jl/pull/) branch so CI can go green. **Remove `[sources]` before registering**, and register in order: this package's 0.4.0 first, then CellMetabolism 0.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)