### PR TITLE
Make benchmark timing tests robust to GC/scheduling artifacts

### DIFF
--- a/test/tests_MetabolicPathway_and_Enzyme_types_and_related_functions.jl
+++ b/test/tests_MetabolicPathway_and_Enzyme_types_and_related_functions.jl
@@ -76,49 +76,49 @@
     @test constant_metabolites(test_pathway) == expected_constant_metabolites
     constant_metabolites(test_pathway) isa Tuple{Vararg{Symbol}}
     benchmark_result = @benchmark constant_metabolites($test_pathway)
-    @test mean(benchmark_result.times) <= 20 #ns
+    @test minimum(benchmark_result.times) <= 20 #ns
     @test benchmark_result.allocs == 0
 
     # Test enzymes function
     @test enzymes(test_pathway) == expected_enzyme_names
     enzymes(test_pathway) isa Tuple{Vararg{Symbol}}
     benchmark_result = @benchmark enzymes($test_pathway)
-    @test mean(benchmark_result.times) <= 20 #ns
+    @test minimum(benchmark_result.times) <= 20 #ns
     @test benchmark_result.allocs == 0
 
     # Test substrates function
     @test substrates(test_pathway) == expected_substrate_names
     substrates(test_pathway) isa Tuple{Vararg{Tuple{Vararg{Symbol}}}}
     benchmark_result = @benchmark substrates($test_pathway)
-    @test mean(benchmark_result.times) <= 20 #ns
+    @test minimum(benchmark_result.times) <= 20 #ns
     @test benchmark_result.allocs == 0
 
     # Test products function
     @test products(test_pathway) == expected_product_names
     products(test_pathway) isa Tuple{Vararg{Tuple{Vararg{Symbol}}}}
     benchmark_result = @benchmark products($test_pathway)
-    @test mean(benchmark_result.times) <= 20 #ns
+    @test minimum(benchmark_result.times) <= 20 #ns
     @test benchmark_result.allocs == 0
 
     # Test stoichiometric_matrix function
     @test stoichiometric_matrix(test_pathway) == expected_stoichiometric_matrix
     stoichiometric_matrix(test_pathway) isa Matrix{Int}
     benchmark_result = @benchmark stoichiometric_matrix($test_pathway)
-    @test mean(benchmark_result.times) <= 20 #ns
+    @test minimum(benchmark_result.times) <= 20 #ns
     @test benchmark_result.allocs == 0
 
     # Test activators function
     @test activators(test_pathway) == expected_activator_names
     activators(test_pathway) isa Tuple{Vararg{Tuple{Vararg{Symbol}}}}
     benchmark_result = @benchmark activators($test_pathway)
-    @test mean(benchmark_result.times) <= 20 #ns
+    @test minimum(benchmark_result.times) <= 20 #ns
     @test benchmark_result.allocs == 0
 
     # Test inhibitors function
     @test inhibitors(test_pathway) == expected_inhibitor_names
     inhibitors(test_pathway) isa Tuple{Vararg{Tuple{Vararg{Symbol}}}}
     benchmark_result = @benchmark inhibitors($test_pathway)
-    @test mean(benchmark_result.times) <= 20 #ns
+    @test minimum(benchmark_result.times) <= 20 #ns
     @test benchmark_result.allocs == 0
 
     enzyme_instances = CellMetabolismBase._generate_Enzymes(test_pathway)
@@ -158,14 +158,14 @@
     @test reactants(test_pathway) == (:A_media, :A, :B, :C, :D)
     reactants(test_pathway) isa Tuple{Vararg{Symbol}}
     benchmark_result = @benchmark reactants($test_pathway)
-    @test mean(benchmark_result.times) <= 20 #ns
+    @test minimum(benchmark_result.times) <= 20 #ns
     @test benchmark_result.allocs == 0
 
     # Test metabolites function
     @test metabolites(test_pathway) == expected_all_metabolite_names
     metabolites(test_pathway) isa Tuple{Vararg{Symbol}}
     benchmark_result = @benchmark metabolites($test_pathway)
-    @test mean(benchmark_result.times) <= 20 #ns
+    @test minimum(benchmark_result.times) <= 20 #ns
     @test benchmark_result.allocs == 0
 
     shorthand_pathway = MetabolicPathway(

--- a/test/tests_make_ODEProblem.jl
+++ b/test/tests_make_ODEProblem.jl
@@ -78,11 +78,11 @@
         $params,
         0.0,
     )
-    @test mean(benchmark_result.times) <= 200 #ns
+    @test minimum(benchmark_result.times) <= 200 #ns
     @test benchmark_result.allocs == 0
 
     benchmark_result = @benchmark test_odes!($dmetabs, $metabs, $params, 0.0)
-    @test mean(benchmark_result.times) <= 200 #ns
+    @test minimum(benchmark_result.times) <= 200 #ns
     @test benchmark_result.allocs == 0
 
     prob_manual = ODEProblem(test_odes!, metabs, (0.0, 1e6), params)
@@ -94,7 +94,7 @@
 
     enzymes = CellMetabolismBase._generate_Enzymes(test_pathway)
     manual_benchmark_result = @benchmark CellMetabolismBase._generate_Enzymes($test_pathway)
-    @test mean(manual_benchmark_result.times) <= 10 #ns
+    @test minimum(manual_benchmark_result.times) <= 10 #ns
     @test manual_benchmark_result.allocs == 0
     @test enzymes isa Tuple{Vararg{Enzyme}}
     @test length(enzymes) == 4
@@ -144,7 +144,7 @@
         reltol = 1e-8,
         save_everystep = false,
     )
-    @test mean(manual_benchmark_result.times) <= 20_000_000 #ns
+    @test minimum(manual_benchmark_result.times) <= 20_000_000 #ns
     @test manual_benchmark_result.allocs < 30_000
 
     package_benchmark_result = @benchmark solve(
@@ -154,17 +154,17 @@
         reltol = 1e-8,
         save_everystep = false,
     )
-    @test mean(package_benchmark_result.times) <= 20_000_000 #ns
+    @test minimum(package_benchmark_result.times) <= 20_000_000 #ns
     @test package_benchmark_result.allocs < 30_000
 
     @test manual_benchmark_result.allocs >= package_benchmark_result.allocs
 
     println(
-        "Manual ODE solve=$(round(mean(manual_benchmark_result.times)/1_000_000; sigdigits=2))ms",
+        "Manual ODE solve=$(round(minimum(manual_benchmark_result.times)/1_000_000; sigdigits=2))ms",
     )
     println("Manual ODE allocations=$(manual_benchmark_result.allocs)")
     println(
-        "Package ODE solve=$(round(mean(package_benchmark_result.times)/1_000_000; sigdigits=2))ms",
+        "Package ODE solve=$(round(minimum(package_benchmark_result.times)/1_000_000; sigdigits=2))ms",
     )
     println("Package ODE allocations=$(package_benchmark_result.allocs)")
 end


### PR DESCRIPTION
## Problem

Several benchmark tests are flaky on CI, e.g.:

```
Accessor functions for MetabolicPathways: Test Failed at .../test/tests_MetabolicPathway_and_Enzyme_types_and_related_functions.jl:100
  Expression: mean(benchmark_result.times) <= 20
   Evaluated: 37.55248014042128 <= 20
```

These assertions used `mean(benchmark_result.times)`, which is sensitive to GC pauses and OS scheduling. A single outlier among the samples drags the mean far above the threshold even though the operation itself is unchanged.

## Investigation

Benchmarking the accessor functions locally confirmed the artifact — the true per-call cost is ~1ns, but individual samples spike to 12–47ns:

```
constant_metabolites  min=0.88  median=0.92  mean=0.94  max=12.79
products              min=0.88  median=0.92  mean=0.96  max=47.54
stoichiometric_matrix min=1.54  median=1.75  mean=1.72  max=11.04
```

On a noisy CI runner, even one GC pause inflates the mean — exactly the `mean=37.55ns` failure observed.

## Fix

Switch all benchmark **timing** assertions from `mean(times)` to `minimum(times)`. The minimum is the standard robust estimator: noise can only *add* time, never subtract, so it reflects genuine compute cost and is immune to these outliers. The two solve-time `println` reports were switched too so the reported number matches what's tested.

- Thresholds are unchanged; since `minimum ≤ mean` always, the change is strictly more lenient and cannot introduce new failures.
- `allocs == 0` assertions are untouched (allocation counts aren't timing-noisy).
- `minimum` is a `Base` function, so no import change is needed.

Affected: `test/tests_MetabolicPathway_and_Enzyme_types_and_related_functions.jl` (9 assertions) and `test/tests_make_ODEProblem.jl` (5 assertions + 2 reports).

🤖 Generated with [Claude Code](https://claude.com/claude-code)